### PR TITLE
Better cypress test names

### DIFF
--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -43,6 +43,7 @@ jobs:
           working-directory: packages/website
           start: yarn test:cypress
           browser: chrome
+          wait-on: 'http://localhost:8000'
           wait-on-timeout: 120
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -105,6 +106,7 @@ jobs:
           working-directory: packages/website
           start: yarn test:cypress
           browser: chrome
+          wait-on: 'http://localhost:8000'
           wait-on-timeout: 120
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -166,6 +168,7 @@ jobs:
           working-directory: packages/website
           start: yarn test:cypress
           browser: chrome
+          wait-on: 'http://localhost:8000'
           wait-on-timeout: 120
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -43,6 +43,7 @@ jobs:
           working-directory: packages/website
           start: yarn test:cypress
           browser: chrome
+          wait-on-timeout: 120
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   os-compatibility:
@@ -104,6 +105,7 @@ jobs:
           working-directory: packages/website
           start: yarn test:cypress
           browser: chrome
+          wait-on-timeout: 120
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ts-compatibility:
@@ -164,6 +166,7 @@ jobs:
           working-directory: packages/website
           start: yarn test:cypress
           browser: chrome
+          wait-on-timeout: 120
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/website/cypress/e2e/course-list/course-list.cy.ts
+++ b/packages/website/cypress/e2e/course-list/course-list.cy.ts
@@ -11,7 +11,7 @@
 // please read our getting started guide:
 // https://on.cypress.io/introduction-to-cypress
 
-describe('example to-do app', () => {
+describe('course list page', () => {
   beforeEach(() => {
     // Cypress starts out with a blank slate for each test
     // so we must tell it to visit our website with the `cy.visit()` command.


### PR DESCRIPTION
- cypress tests
- Run cypress tests in first CI build stage
- cypress config at root
- Explicit specification of cypress config file in github workflow
- remove explicit build before cypress tests run
- fix path to cypress config file
- Run cypress tests in first CI build stage
- define cwd for cypress gha
- run cypress on port :8000
- fix two failing tests
- better test names
