### PR TITLE
fix: link in intro section to fundamentals

### DIFF
--- a/packages/website/content/blog/intermediate-v2/01-project-setup/index.md
+++ b/packages/website/content/blog/intermediate-v2/01-project-setup/index.md
@@ -59,7 +59,7 @@ Also... some practical experience is important
 
 As long as you can access the following websites, you should require no further setup :tada:
 
-- [The course website you're reading right now](https://fun-v3.typescript-training.com)
+- [The course website you're reading right now](https://www.typescript-training.com/course/fundamentals-v4)
 - [The official TypeScript website](https://www.typescriptlang.org)
 
 ## Which of your TypeScript courses is right for me?


### PR DESCRIPTION
Hi, I'm just watching live training on frontend masters and though I can fix that wrong link...