### PR TITLE
Equality check instead of assignment when comparing private properties

### DIFF
--- a/packages/website/content/blog/fundamentals-v4/11-classes/index.md
+++ b/packages/website/content/blog/fundamentals-v4/11-classes/index.md
@@ -354,6 +354,7 @@ class Car {
       #serialNumber in other) {
         other
 //       ^?
+        // Shouldn't this have a `==` or `===`? Seems like we want to return True if they're the same or False if not
         return other.#serialNumber = this.#serialNumber
       }
       return false


### PR DESCRIPTION
```ts
equals(other: unknown) {
    if (other && typeof other === "object" && #serialNumber in other) {
      other;
      // ^?
      return other.#serialNumber = this.#serialNumber;
    }
    return false;
  }
```

I believe that the intent was to return true not to assign a new value to `#serialNumber`