### PR TITLE
docs: fix urls to courses wibsite

### DIFF
--- a/packages/website/content/blog/enterprise-v2/01-intro/index.md
+++ b/packages/website/content/blog/enterprise-v2/01-intro/index.md
@@ -63,7 +63,7 @@ Beyond TypeScript, should be familiar with most of the topics below
 
 As long as you can access the following websites, you should require no further setup :tada:
 
-- [The course website you're reading right now](https://fun-v3.typescript-training.com)
+- [The course website you're reading right now](https://www.typescript-training.com/course/enterprise-v2)
 - [The official TypeScript website](https://www.typescriptlang.org)
 
 If you'd like to follow along with interactive examples, please install [Volta](https://volta.sh)

--- a/packages/website/content/blog/fundamentals-v3/01-intro/index.md
+++ b/packages/website/content/blog/fundamentals-v3/01-intro/index.md
@@ -85,7 +85,7 @@ window.setInterval
 
 As long as you can access the following websites, you should require no further setup :tada:
 
-- [The course website you're reading right now](https://fun-v3.typescript-training.com)
+- [The course website you're reading right now](https://www.typescript-training.com/course/fundamentals-v3)
 - [The official TypeScript website](https://www.typescriptlang.org)
 
 <!-- ## Which of your TypeScript courses is right for me?

--- a/packages/website/content/blog/fundamentals-v4/01-intro/index.md
+++ b/packages/website/content/blog/fundamentals-v4/01-intro/index.md
@@ -88,7 +88,7 @@ window.se
 
 As long as you can access the following websites, you should require no further setup :tada:
 
-- [The course website you're reading right now](https://fun-v3.typescript-training.com)
+- [The course website you're reading right now](https://www.typescript-training.com/course/fundamentals-v4)
 - [The official TypeScript website](https://www.typescriptlang.org)
 
 If you'd like to follow along with interactive examples, please install [Volta](https://volta.sh)

--- a/packages/website/content/blog/intermediate-v1/01-project-setup/index.md
+++ b/packages/website/content/blog/intermediate-v1/01-project-setup/index.md
@@ -57,7 +57,7 @@ Also... some practical experience is important
 
 As long as you can access the following websites, you should require no further setup :tada:
 
-- [The course website you're reading right now](https://fun-v3.typescript-training.com)
+- [The course website you're reading right now](https://www.typescript-training.com/course/intermediate-v1)
 - [The official TypeScript website](https://www.typescriptlang.org)
 
 ## Which of your TypeScript courses is right for me?

--- a/packages/website/content/blog/intermediate-v2/01-project-setup/index.md
+++ b/packages/website/content/blog/intermediate-v2/01-project-setup/index.md
@@ -58,7 +58,7 @@ Also... some practical experience always helps!
 
 As long as you can access the following websites, you should require no further setup :tada:
 
-- [The course website you're reading right now](https://fun-v3.typescript-training.com)
+- [The course website you're reading right now](https://www.typescript-training.com/course/intermediate-v2)
 - [The official TypeScript website](https://www.typescriptlang.org)
 
 If you'd like to follow along with interactive examples, please install [Volta](https://volta.sh)


### PR DESCRIPTION
Not sure if I have to use direct `https://www.typescript-training.com` or custom course URL, but `https://fun-v3.typescript-training.com` is not working.
Thanks for your course, by the way:)